### PR TITLE
Callback Cancellation

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -10,12 +10,31 @@ setDefaultProps({
     bounce: true
 });
 
+const renderItem = (deleteCallback) => (item, idx) => {
+	return (
+		<OnVisible
+			className="box"
+			percent={10}
+			key={idx}
+		>
+			<div data-idx={`box: ${idx}`}
+				style={{
+					backgroundColor: item.bg,
+					transitionDelay: `${idx % 3 * 100}ms`
+				}}
+			 	onClick={deleteCallback(item.id)}
+			/>
+		</OnVisible>
+	);
+}
+
 class Colors extends Component {
     constructor() {
         super(...arguments);
-        this.renderItem = this.renderItem.bind(this);
+        this.deleteColor = this.deleteColor.bind(this);
         const colors = new Array(NUM_ITEMS).fill('').map((i, idx) => {
             return {
+            	id: idx,
                 bg: `hsl(${(idx / NUM_ITEMS) * 360},100%,50%)`
             };
         });
@@ -24,24 +43,15 @@ class Colors extends Component {
             count: 0
         };
     }
-    renderItem(item, idx) {
-        return (
-            <OnVisible
-                className="box"
-                percent={10}
-                key={idx}
-            >
-                <div data-idx={`box: ${idx}`} style={{
-                    backgroundColor: item.bg,
-                    transitionDelay: `${idx % 3 * 100}ms`
-                }} />
-            </OnVisible>
-        );
-    }
+	deleteColor(colorId) {
+    	const { colors } = this.state;
+    	const withoutColorId = colors.filter(item => item.id !== colorId);
+    	// this.setState({colors: withoutColorId});
+	}
     render() {
         return (
             <div className="colors">
-                {this.state.colors.map(this.renderItem)}
+                {this.state.colors.map(renderItem(this.deleteColor))}
             </div>
         );
     }

--- a/demo/index.js
+++ b/demo/index.js
@@ -10,19 +10,20 @@ setDefaultProps({
     bounce: true
 });
 
-const renderItem = (deleteCallback) => (item, idx) => {
+const renderItem = (deleteCallback) => (item) => {
+	const itemToRemove = Math.min(item.id + 6, NUM_ITEMS);
 	return (
 		<OnVisible
 			className="box"
 			percent={10}
-			key={idx}
+			key={item.id}
 		>
-			<div data-idx={`box: ${idx}`}
+			<div data-idx={`box: ${item.id}, click to cancel ${itemToRemove}`}
 				style={{
 					backgroundColor: item.bg,
-					transitionDelay: `${idx % 3 * 100}ms`
+					transitionDelay: `${item.id % 3 * 100}ms`
 				}}
-			 	onClick={deleteCallback(item.id)}
+			 	onClick={() => deleteCallback(itemToRemove)}
 			/>
 		</OnVisible>
 	);
@@ -45,8 +46,9 @@ class Colors extends Component {
     }
 	deleteColor(colorId) {
     	const { colors } = this.state;
-    	const withoutColorId = colors.filter(item => item.id !== colorId);
-    	// this.setState({colors: withoutColorId});
+		console.log('deleting now: ', colorId);
+		const withoutColorId = colors.filter(item => item.id !== colorId);
+		this.setState({colors: withoutColorId});
 	}
     render() {
         return (

--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,7 @@ class OnVisible extends Component {
     stopListening() {
         window.removeEventListener('scroll', this.onScroll);
         window.removeEventListener('resize', this.onScroll);
-        this.onScroll.cancel();
+        this.onScroll.prototype.cancel();
     }
     render() {
         const { visible } = this.state;

--- a/src/index.js
+++ b/src/index.js
@@ -52,6 +52,7 @@ class OnVisible extends Component {
     stopListening() {
         window.removeEventListener('scroll', this.onScroll);
         window.removeEventListener('resize', this.onScroll);
+        this.onScroll.cancel();
     }
     render() {
         const { visible } = this.state;
@@ -63,7 +64,7 @@ class OnVisible extends Component {
           <div
               style={this.props.style}
               className={classes}
-              ref={el => { this.holder = el || this.holder; }}
+              ref={el => { this.holder = el; }}
           >
             {this.props.children}
           </div>

--- a/src/lib/bindRaf.js
+++ b/src/lib/bindRaf.js
@@ -31,7 +31,7 @@ export const bindRaf = (fn) => {
 		cancellationToken = true;
 	};
 
-	callbackGenerator.cancel = cancelCallback;
+	callbackGenerator.prototype.cancel = cancelCallback;
 
 	return callbackGenerator;
 };

--- a/src/lib/bindRaf.js
+++ b/src/lib/bindRaf.js
@@ -1,5 +1,3 @@
-import { protomix } from "./protomix";
-
 export const bindRaf = (fn) => {
 	let isRunning = null;
 	let self = null;
@@ -11,6 +9,9 @@ export const bindRaf = (fn) => {
 		if (!cancellationToken) {
 			fn.apply(self, args);
 		}
+		// else {
+		// 	console.log('yay i was deletd!!!');
+		// }
 	};
 
 	const callbackGenerator = () => {
@@ -24,13 +25,14 @@ export const bindRaf = (fn) => {
 
 		isRunning = true;
 		requestAnimationFrame(run);
+		// setTimeout(run, 5000);
 	};
 
 	const cancelCallback = () => {
 		cancellationToken = true;
-	}
+	};
 
-	return protomix(callbackGenerator, {
-		cancel: cancelCallback,
-	})
+	callbackGenerator.cancel = cancelCallback;
+
+	return callbackGenerator;
 };

--- a/src/lib/bindRaf.js
+++ b/src/lib/bindRaf.js
@@ -1,16 +1,22 @@
+import { protomix } from "./protomix";
+
 export const bindRaf = (fn) => {
 	let isRunning = null;
 	let self = null;
 	let args = null;
+	let cancellationToken = null;
 
 	const run = () => {
 		isRunning = false;
-		fn.apply(self, args);
+		if (!cancellationToken) {
+			fn.apply(self, args);
+		}
 	};
 
-	return () => {
+	const callbackGenerator = () => {
 		self = this;
 		args = arguments;
+		cancellationToken = false;
 
 		if (isRunning) {
 			return;
@@ -19,4 +25,12 @@ export const bindRaf = (fn) => {
 		isRunning = true;
 		requestAnimationFrame(run);
 	};
+
+	const cancelCallback = () => {
+		cancellationToken = true;
+	}
+
+	return protomix(callbackGenerator, {
+		cancel: cancelCallback,
+	})
 };

--- a/src/lib/bindRaf.js
+++ b/src/lib/bindRaf.js
@@ -2,7 +2,7 @@ export const bindRaf = (fn) => {
 	let isRunning = null;
 	let self = null;
 	let args = null;
-	let cancellationToken = null;
+	let cancellationToken = false;
 
 	const run = () => {
 		isRunning = false;
@@ -17,7 +17,6 @@ export const bindRaf = (fn) => {
 	const callbackGenerator = () => {
 		self = this;
 		args = arguments;
-		cancellationToken = false;
 
 		if (isRunning) {
 			return;

--- a/src/lib/protomix.js
+++ b/src/lib/protomix.js
@@ -1,0 +1,7 @@
+export const protomix = (constructor, mix) => {
+	for(const i in mix) {
+		if(mix.hasOwnProperty(i)) {
+			constructor.prototype[i]=mix[i];
+		}
+	}
+}

--- a/src/lib/protomix.js
+++ b/src/lib/protomix.js
@@ -1,7 +1,0 @@
-export const protomix = (constructor, mix) => {
-	for(const i in mix) {
-		if(mix.hasOwnProperty(i)) {
-			constructor.prototype[i]=mix[i];
-		}
-	}
-}


### PR DESCRIPTION
pending completion of https://github.com/dazld/react-on-visible/pull/14 this adds cancellation abilities to bindRaf.

There was an issue on my large website where I had allot going on, so on crappier browsers I was getting null errors when the bound element was cancelled whilest a callback was waiting for x seconds to occur.

This pr adds the ability to call .cancel on the callback you wrap within the bindRaf.

To test this please open bindRaf.js and uncomment out the else statement and change the requestAnimationFrame for setTimeout. Before checkin to main repo we will need to remove this test code.

Then simply wait for the demo to load the first 6 blocks, scroll untill you see the area in which the 7th block will load (it won't show as the setTimeout delays 5 seconds) then click on the first block as it will delete the 7th block that hasn't rendered yet. Then after 5 seconds you will get yay i was deleted which demo's 7th block whilest the callback to run content dependant on the element existing.

Let me know what you think.